### PR TITLE
[IMP] Somewhat centralize Travis & Add docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,23 +6,17 @@ addons:
 language: python
 
 python:
-  - "2.7"
+    - "2.7"
 
 virtualenv:
-  system_site_packages: true
+    system_site_packages: true
 
-install:
-  - pip install coveralls
-  - pip install codecov --user
-  - pip install codeclimate-test-reporter
-  - pip install -r requirements.txt
-  - pip install .
+env:
+    global:
+        - TESTS="0" LINT_CHECK="0" DOCS="0" VERSION="0.1.0" RELEASE="0.1.0" PROJECT="Python-CFSSL" BRANCH_PROD="master" BRANCH_DOC="gh-pages"
+    matrix:
+        - TESTS="1"
+        - DOCS="1"
 
-# command to run tests
 script:
-  - coverage run setup.py test
-  
-after_success:
-  - coveralls
-  - codecov
-  - codeclimate-test-reporter
+    - wget -O - https://gist.githubusercontent.com/lasley/e547cc2f66cff91e9494ad46b69b9571/raw/6b2cf174988d62e79b0ebedbc0dfb013d65e8dcc/Python%2520Travis%2520Tests | bash

--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,8 @@ Setup
 Usage
 -----
 
+`API Documentation <https://laslabs.github.io/python-cfssl>`_
+
 Known Issues / Road Map
 -----------------------
 


### PR DESCRIPTION
Docs at https://laslabs.github.io/python-cfssl/ were generated while this was based on the #4 branch, and with `BRANCH_PROD` in the Travis file set to `feature/master/sphinx`. Raw files are at https://github.com/laslabs/Python-CFSSL/tree/gh-pages

I added Lint in my build script to, but it's failing here and I need to work out some kinks anyways. I will submit a fix once I move the Travis into a repo and stuff after testing a bit. That said, it is disabled in the Travis

Depends:
- [ ] #4 